### PR TITLE
Use php from PATH by default and disable ANSI output

### DIFF
--- a/SymfonyCommander.py
+++ b/SymfonyCommander.py
@@ -84,9 +84,9 @@ class SymfonyCommanderBase:
         os.chdir(self.base_directory)
         # CMD:
         if not self.php_command:
-            command = "app/console " + command
+            command = "php app/console --no-ansi " + command
         else:
-            command = self.php_command + " app/console " + command
+            command = self.php_command + " app/console --no-ansi " + command
         result, e = subprocess.Popen(command, stdout=subprocess.PIPE, shell=True, cwd=self.base_directory).communicate()
         if e:
             return e


### PR DESCRIPTION
Using php from the PATH makes more sense, that's what the `#!/bin/env php` on top of app/console does anyway, except this also works on windows now. As for the ANSI output, it's another thing on windows, if you have ANSICON installed it will display colors even in terminals that don't support them, so this avoid ugly output.

Thanks for the great work btw :)
